### PR TITLE
Rename BrokerURLS to URLs for kafka plugin

### DIFF
--- a/examples/kafka/load-conf.yaml
+++ b/examples/kafka/load-conf.yaml
@@ -2,7 +2,7 @@ plugins:
   data:
     kafka.messages:
       type: kafka
-      brokerURLs:
+      URLs:
         - broker:29092
       topics:
         - users


### PR DESCRIPTION
we decided to use the urls/ulr across all plugins